### PR TITLE
Create Docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+##########################################################
+# Dockerfile to build a Genomic-fluidity-scripts container image
+# Based on Ubuntu
+############################################################
+
+# Set the base image to the BioPerl prebuilt prerequisites image
+
+FROM bioperl/bioperl-deps
+
+# File Author / Maintainer
+MAINTAINER Nelly Selem <nselem84@gmail.com>
+
+# First Bioperl Modules copied from Hilmar Lapp <hlapp@drycafe.net> bioperl
+# Install modules recommended by BioPerl.
+# We can't include Bio::ASN1::EntrezGene here yet, because it declares
+# a dependency on BioPerl, thus pulling in BioPerl first.
+RUN cpanm \
+  Bio::Phylo
+
+# -------------------------------------------------------------
+# Install BioPerl from GitHub current master branch.
+#
+# This is the actual installation step of BioPerl itself :-)
+# -------------------------------------------------------------
+RUN cpanm -v \
+  https://github.com/bioperl/bioperl-live/archive/master.tar.gz
+
+# Install modules recommended by BioPerl that depend on BioPerl.
+# (Don't ask. See above.)
+RUN cpanm \
+  Bio::ASN1::EntrezGene
+
+
+## Cloning fluidity scripts Weitz Group
+RUN apt-get update && apt-get install -y git
+RUN git clone https://github.com/WeitzGroup/Genomic-fluidity-scripts
+
+## Bioperl module
+RUN cpanm \
+Bio::Tools::Run::StandAloneBlast
+
+# Installing blast legacy
+RUN apt-get install -y blast2
+
+RUN mkdir /usr/src/fluidity
+COPY . /usr/src/fluidity
+ENV PATH $PATH:/Genomic-fluidity-scripts:
+WORKDIR /Genomic-fluidity-scripts 
+RUN chmod +x *
+WORKDIR /usr/src/fluidity 
+


### PR DESCRIPTION
I want to use the scripts but formatdb is no longer available on new blast because is an older blast version. Docker is a way to package sripts and applications with their dependencies in order that they can still running (https://www.docker.com/). On this docker file I packaged Bioperl, blast2 (older blast) and your scripts.  To use it you need to install docker as explained on `https://docs.docker.com/engine/installation/linux/   Once docker is installed can be used in multiple applicactions.
After docker installation genomic fluidity app must be build:
`docker build -t genomicfluidity . `
and run 
`docker run -t -i -v /mygenomesDirectory:/usr/src/fluidity genomicfluidity /bin/bash`

And can be used.
It works fine for me on NCBI genomes, and may be useful for other people who has docker.
Unfortunately it doesn't work fine with RAST genomes gbk format.
